### PR TITLE
test: Use `command -v` instead of `which`

### DIFF
--- a/test/expected/psql.out
+++ b/test/expected/psql.out
@@ -4,7 +4,7 @@ CREATE FUNCTION query (x int) RETURNS text
 LANGUAGE plsh
 AS $$
 #!/bin/sh
-if which psql >/dev/null; then
+if command -v psql >/dev/null; then
     psql -X -At -c "select b from pbar where a = $1"
 else
     echo 'no PATH?' 1>&2

--- a/test/expected/psql_1.out
+++ b/test/expected/psql_1.out
@@ -4,7 +4,7 @@ CREATE FUNCTION query (x int) RETURNS text
 LANGUAGE plsh
 AS $$
 #!/bin/sh
-if which psql >/dev/null; then
+if command -v psql >/dev/null; then
     psql -X -At -c "select b from pbar where a = $1"
 else
     echo 'no PATH?' 1>&2

--- a/test/sql/psql.sql
+++ b/test/sql/psql.sql
@@ -5,7 +5,7 @@ CREATE FUNCTION query (x int) RETURNS text
 LANGUAGE plsh
 AS $$
 #!/bin/sh
-if which psql >/dev/null; then
+if command -v psql >/dev/null; then
     psql -X -At -c "select b from pbar where a = $1"
 else
     echo 'no PATH?' 1>&2


### PR DESCRIPTION
/usr/bin/which is deprecated on Debian unstable:

ERROR:  query: /usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.